### PR TITLE
Add contracts tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "biome format --write"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@number-flow/react": "^0.5.10",
     "@onflow/fcl": "^1.20.2",
     "@tanstack/react-query": "^5.90.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@monaco-editor/react':
+        specifier: ^4.7.0
+        version: 4.7.0(monaco-editor@0.54.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@number-flow/react':
         specifier: ^0.5.10
         version: 0.5.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -308,6 +311,16 @@ packages:
 
   '@lit/reactive-element@1.6.3':
     resolution: {integrity: sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==}
+
+  '@monaco-editor/loader@1.6.1':
+    resolution: {integrity: sha512-w3tEnj9HYEC73wtjdpR089AqkUPskFRcdkxsiSFt3SoUc3OHpmu+leP94CXBm4mHfefmhsdfI0ZQu6qJ0wgtPg==}
+
+  '@monaco-editor/react@4.7.0':
+    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@motionone/animation@10.18.0':
     resolution: {integrity: sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==}
@@ -889,6 +902,9 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
+  dompurify@3.1.7:
+    resolution: {integrity: sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1172,6 +1188,11 @@ packages:
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1191,6 +1212,9 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
+
+  monaco-editor@0.54.0:
+    resolution: {integrity: sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==}
 
   motion-dom@12.23.23:
     resolution: {integrity: sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==}
@@ -1579,6 +1603,9 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2048,6 +2075,17 @@ snapshots:
   '@lit/reactive-element@1.6.3':
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.4.0
+
+  '@monaco-editor/loader@1.6.1':
+    dependencies:
+      state-local: 1.0.7
+
+  '@monaco-editor/react@4.7.0(monaco-editor@0.54.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@monaco-editor/loader': 1.6.1
+      monaco-editor: 0.54.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   '@motionone/animation@10.18.0':
     dependencies:
@@ -3003,6 +3041,8 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  dompurify@3.1.7: {}
+
   eastasianwidth@0.2.0: {}
 
   emoji-regex@8.0.0: {}
@@ -3252,6 +3292,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  marked@14.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -3268,6 +3310,11 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.2
+
+  monaco-editor@0.54.0:
+    dependencies:
+      dompurify: 3.1.7
+      marked: 14.0.0
 
   motion-dom@12.23.23:
     dependencies:
@@ -3639,6 +3686,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   split2@4.2.0: {}
+
+  state-local@1.0.7: {}
 
   string-width@4.2.3:
     dependencies:

--- a/src/app/[network]/account/[id]/contracts/content.tsx
+++ b/src/app/[network]/account/[id]/contracts/content.tsx
@@ -1,0 +1,94 @@
+"use client";
+import CodeBlock from "@/components/flowscan/CodeBlock";
+import { ExtraTag, ExtraTagType } from "@/components/flowscan/ExtraTag";
+import FatRow from "@/components/flowscan/FatRow";
+import JumpingDots from "@/components/flowscan/JumpingDots";
+import { useAccountDetails } from "@/hooks/useAccountDetails";
+import useAccountResolver from "@/hooks/useAccountResolver";
+import { cn } from "@/lib/utils";
+import { Code, Globe } from "lucide-react";
+import { useParams } from "next/navigation";
+
+export default function AccountContractsContent() {
+  const { id } = useParams();
+
+  const { data: resolved, isPending: isResolving } = useAccountResolver(
+    id as string
+  );
+  const address = resolved?.owner;
+
+  const { data, isPending } = useAccountDetails(address);
+  const haveData = !isPending && Boolean(data?.contracts);
+
+  const contractList = Object.keys(data?.contracts || {});
+  const haveContracts = haveData && contractList.length > 0;
+
+  if (!address)
+    return <p className={"opacity-50"}>Unable to resolve account address.</p>;
+  return (
+    <div
+      className={
+        "fat-row-column flex w-full flex-col items-start justify-start gap-px"
+      }
+    >
+      {isPending && <JumpingDots />}
+      {haveContracts &&
+        contractList.map((key) => {
+          const code = data?.contracts[key];
+          const numberOfLines = code?.split("\r\n").length || 0;
+
+          const details = (
+            <div
+              className={
+                "flex w-full flex-col items-start justify-start gap-2 bg-neutral-500 p-4"
+              }
+            >
+              <div className={"flex w-full flex-col gap-4"}>
+                <CodeBlock code={code || ""} />
+              </div>
+            </div>
+          );
+
+          return (
+            <FatRow id={"contract"} details={details} className={[]} key={key}>
+              <div
+                className={cn(
+                  "relative flex w-full flex-col items-start justify-start gap-4 p-4",
+                  "md:gap-3 md:p-4"
+                )}
+              >
+                <div className={"flex w-full flex-row justify-between gap-2"}>
+                  <a
+                    key={key}
+                    href={`/contract/A.${address.slice(2)}.${key}?tab=deployments`}
+                  >
+                    <ExtraTag
+                      title={`View ${key} contract on Flowscan`}
+                      className={"text-green-300"}
+                      label={key}
+                      type={ExtraTagType.system_fee}
+                      category={<Globe className={"h-3 w-3"} />}
+                      isLink
+                    />
+                  </a>
+                  <span>
+                    <ExtraTag
+                      title={`Lines of code: ${numberOfLines}`}
+                      label={numberOfLines}
+                      category={<Code className={"h-4 w-4"} />}
+                      type={ExtraTagType.system_fee}
+                    />
+                  </span>
+                </div>
+              </div>
+            </FatRow>
+          );
+        })}
+      {!haveContracts && !isPending && (
+        <p className={"opacity-50"}>
+          This account does not have any contracts deployed to it&#39;s storage
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/[network]/account/[id]/contracts/page.tsx
+++ b/src/app/[network]/account/[id]/contracts/page.tsx
@@ -1,0 +1,15 @@
+/*--------------------------------------------------------------------------------------------------------------------*/
+import { Suspense } from "react";
+import JumpingDots from "@/components/flowscan/JumpingDots";
+import AccountContractsContent from "./content";
+
+/*--------------------------------------------------------------------------------------------------------------------*/
+export default function AccountContracts() {
+  return (
+    <div className={"w-full"}>
+      <Suspense fallback={<JumpingDots />}>
+        <AccountContractsContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/[network]/account/[id]/navigation.tsx
+++ b/src/app/[network]/account/[id]/navigation.tsx
@@ -47,6 +47,9 @@ export default function AccountNavigation() {
       <NavigationLink to={"public-storage"} baseUrl={baseUrl}>
         Public Storage
       </NavigationLink>
+      <NavigationLink to={"contracts"} baseUrl={baseUrl}>
+        Contracts
+      </NavigationLink>
     </div>
   );
 }

--- a/src/components/flowscan/CodeBlock/cadence.ts
+++ b/src/components/flowscan/CodeBlock/cadence.ts
@@ -1,0 +1,470 @@
+// This is a TextMate grammar distributed by `starry-night`.
+// This grammar is developed at
+// <https://github.com/onflow/vscode-cadence>
+// and licensed `apache-2.0`.
+// See <https://github.com/wooorm/starry-night> for more info.
+/** @type {import('../lib/index.js').Grammar} */
+const grammar = {
+  extensions: [".cdc"],
+  names: ["cadence"],
+  patterns: [
+    { include: "#comments" },
+    { include: "#expressions" },
+    { include: "#declarations" },
+    { include: "#keywords" },
+    { include: "#code-block" },
+    { include: "#composite" },
+    { include: "#event" },
+  ],
+  repository: {
+    "code-block": {
+      begin: "\\{",
+      beginCaptures: { 0: { name: "punctuation.section.scope.begin.cadence" } },
+      end: "\\}",
+      endCaptures: { 0: { name: "punctuation.section.scope.end.cadence" } },
+      patterns: [{ include: "$self" }],
+    },
+    comments: {
+      patterns: [
+        {
+          captures: { 1: { name: "punctuation.definition.comment.cadence" } },
+          match: "\\A^(#!).*$\\n?",
+          name: "comment.line.number-sign.cadence",
+        },
+        {
+          begin: "/\\*\\*(?!/)",
+          beginCaptures: {
+            0: { name: "punctuation.definition.comment.begin.cadence" },
+          },
+          end: "\\*/",
+          endCaptures: {
+            0: { name: "punctuation.definition.comment.end.cadence" },
+          },
+          name: "comment.block.documentation.cadence",
+          patterns: [{ include: "#nested" }],
+        },
+        {
+          begin: "/\\*:",
+          beginCaptures: {
+            0: { name: "punctuation.definition.comment.begin.cadence" },
+          },
+          end: "\\*/",
+          endCaptures: {
+            0: { name: "punctuation.definition.comment.end.cadence" },
+          },
+          name: "comment.block.documentation.playground.cadence",
+          patterns: [{ include: "#nested" }],
+        },
+        {
+          begin: "/\\*",
+          beginCaptures: {
+            0: { name: "punctuation.definition.comment.begin.cadence" },
+          },
+          end: "\\*/",
+          endCaptures: {
+            0: { name: "punctuation.definition.comment.end.cadence" },
+          },
+          name: "comment.block.cadence",
+          patterns: [{ include: "#nested" }],
+        },
+        {
+          match: "\\*/",
+          name: "invalid.illegal.unexpected-end-of-block-comment.cadence",
+        },
+        {
+          begin: "(^[ \\t]+)?(?=//)",
+          beginCaptures: {
+            1: { name: "punctuation.whitespace.comment.leading.cadence" },
+          },
+          end: "(?!\\G)",
+          patterns: [
+            {
+              begin: "///",
+              beginCaptures: {
+                0: { name: "punctuation.definition.comment.cadence" },
+              },
+              end: "^",
+              name: "comment.line.triple-slash.documentation.cadence",
+            },
+            {
+              begin: "//:",
+              beginCaptures: {
+                0: { name: "punctuation.definition.comment.cadence" },
+              },
+              end: "^",
+              name: "comment.line.double-slash.documentation.cadence",
+            },
+            {
+              begin: "//",
+              beginCaptures: {
+                0: { name: "punctuation.definition.comment.cadence" },
+              },
+              end: "^",
+              name: "comment.line.double-slash.cadence",
+            },
+          ],
+        },
+      ],
+      repository: {
+        nested: {
+          begin: "/\\*",
+          end: "\\*/",
+          patterns: [{ include: "#nested" }],
+        },
+      },
+    },
+    composite: {
+      begin:
+        "\\b((?:(?:struct|resource|contract)(?:\\s+interface)?)|transaction|enum)\\s+([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)",
+      beginCaptures: {
+        1: { name: "storage.type.$1.cadence" },
+        2: { name: "entity.name.type.$1.cadence" },
+      },
+      end: "(?<=\\})",
+      name: "meta.definition.type.composite.cadence",
+      patterns: [
+        { include: "#comments" },
+        { include: "#conformance-clause" },
+        {
+          begin: "\\{",
+          beginCaptures: {
+            0: { name: "punctuation.definition.type.begin.cadence" },
+          },
+          end: "\\}",
+          endCaptures: {
+            0: { name: "punctuation.definition.type.end.cadence" },
+          },
+          name: "meta.definition.type.body.cadence",
+          patterns: [{ include: "$self" }],
+        },
+      ],
+    },
+    "conformance-clause": {
+      begin: "(:)(?=\\s*\\{)|(:)\\s*",
+      beginCaptures: {
+        1: { name: "invalid.illegal.empty-conformance-clause.cadence" },
+        2: { name: "punctuation.separator.conformance-clause.cadence" },
+      },
+      end: "(?!\\G)$|(?=[={}])",
+      name: "meta.conformance-clause.cadence",
+      patterns: [
+        {
+          begin: "\\G",
+          end: "(?!\\G)$|(?=[={}])",
+          patterns: [{ include: "#comments" }, { include: "#type" }],
+        },
+      ],
+    },
+    declarations: {
+      patterns: [
+        { include: "#var-let-declaration" },
+        { include: "#function" },
+        { include: "#initializer" },
+      ],
+    },
+    event: {
+      begin: "\\b(event)\\b\\s+([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)\\s*",
+      beginCaptures: {
+        1: { name: "storage.type.event.cadence" },
+        2: { name: "entity.name.type.event.cadence" },
+      },
+      end: "(?<=\\))|$",
+      name: "meta.definition.type.event.cadence",
+      patterns: [{ include: "#comments" }, { include: "#parameter-clause" }],
+    },
+    "expression-element-list": {
+      patterns: [
+        { include: "#comments" },
+        {
+          begin: "([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)\\s*(:)",
+          beginCaptures: {
+            1: { name: "support.function.any-method.cadence" },
+            2: { name: "punctuation.separator.argument-label.cadence" },
+          },
+          end: "(?=[,)\\]])",
+          patterns: [{ include: "#expressions" }],
+        },
+        {
+          begin: "(?![,)\\]])(?=\\S)",
+          end: "(?=[,)\\]])",
+          patterns: [{ include: "#expressions" }],
+        },
+      ],
+    },
+    expressions: {
+      patterns: [
+        { include: "#comments" },
+        { include: "#function-call-expression" },
+        { include: "#literals" },
+        { include: "#operators" },
+        { include: "#language-variables" },
+      ],
+    },
+    function: {
+      begin: "\\b(fun)\\b\\s+([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)\\s*",
+      beginCaptures: {
+        1: { name: "storage.type.function.cadence" },
+        2: { name: "entity.name.function.cadence" },
+      },
+      end: "(?<=\\})|$",
+      name: "meta.definition.function.cadence",
+      patterns: [
+        { include: "#comments" },
+        { include: "#parameter-clause" },
+        { include: "#function-result" },
+        {
+          begin: "(\\{)",
+          beginCaptures: {
+            1: { name: "punctuation.section.function.begin.cadence" },
+          },
+          end: "(\\})",
+          endCaptures: {
+            1: { name: "punctuation.section.function.end.cadence" },
+          },
+          name: "meta.definition.function.body.cadence",
+          patterns: [{ include: "$self" }],
+        },
+      ],
+    },
+    "function-call-expression": {
+      patterns: [
+        {
+          begin: "(?!(?:set|init))([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)\\s*(\\()",
+          beginCaptures: {
+            1: { name: "support.function.any-method.cadence" },
+            4: { name: "punctuation.definition.arguments.begin.cadence" },
+          },
+          end: "\\)",
+          endCaptures: {
+            0: { name: "punctuation.definition.arguments.end.cadence" },
+          },
+          name: "meta.function-call.cadence",
+          patterns: [{ include: "#expression-element-list" }],
+        },
+      ],
+    },
+    "function-result": {
+      begin: "(?<![/=\\-+!*%<>&|\\^~.])(:)(?![/=\\-+!*%<>&|\\^~.])\\s*",
+      beginCaptures: {
+        1: { name: "keyword.operator.function-result.cadence" },
+      },
+      end: "(?!\\G)(?=\\{|;)|$",
+      name: "meta.function-result.cadence",
+      patterns: [{ include: "#type" }],
+    },
+    initializer: {
+      begin: "(?<!\\.)\\b(init)\\s*(?=\\(|<)",
+      beginCaptures: { 1: { name: "storage.type.function.cadence" } },
+      end: "(?<=\\})|$",
+      name: "meta.definition.function.initializer.cadence",
+      patterns: [
+        { include: "#comments" },
+        { include: "#parameter-clause" },
+        {
+          begin: "(\\{)",
+          beginCaptures: {
+            1: { name: "punctuation.section.function.begin.cadence" },
+          },
+          end: "(\\})",
+          endCaptures: {
+            1: { name: "punctuation.section.function.end.cadence" },
+          },
+          name: "meta.definition.function.body.cadence",
+          patterns: [{ include: "$self" }],
+        },
+      ],
+    },
+    keywords: {
+      patterns: [
+        {
+          match: "(?<!\\.)\\b(?:if|else|switch|case|default)\\b",
+          name: "keyword.control.branch.cadence",
+        },
+        {
+          match: "(?<!\\.)\\b(?:return|continue|break)\\b",
+          name: "keyword.control.transfer.cadence",
+        },
+        {
+          match: "(?<!\\.)\\b(?:while|for|in)\\b",
+          name: "keyword.control.loop.cadence",
+        },
+        {
+          match: "(?<!\\.)\\b(?:pre|post|prepare|execute|create|destroy|emit)\\b",
+          name: "keyword.other.cadence",
+        },
+        {
+          match:
+            "(?<!\\.)\\b(?:private|pub(?:\\(set\\))?|access\\((?:self|contract|account|all)\\))\\b",
+          name: "keyword.other.declaration-specifier.accessibility.cadence",
+        },
+        {
+          match: "\\b(?:init|destroy)\\b",
+          name: "storage.type.function.cadence",
+        },
+        {
+          match: "(?<!\\.)\\b(?:import|from)\\b",
+          name: "keyword.control.import.cadence",
+        },
+      ],
+    },
+    "language-variables": {
+      patterns: [{ match: "\\b(self)\\b", name: "variable.language.cadence" }],
+    },
+    literals: {
+      patterns: [
+        { include: "#boolean" },
+        { include: "#numeric" },
+        { include: "#string" },
+        { match: "\\bnil\\b", name: "constant.language.nil.cadence" },
+      ],
+      repository: {
+        boolean: {
+          match: "\\b(true|false)\\b",
+          name: "constant.language.boolean.cadence",
+        },
+        numeric: {
+          patterns: [
+            { include: "#binary" },
+            { include: "#octal" },
+            { include: "#decimal" },
+            { include: "#hexadecimal" },
+          ],
+          repository: {
+            binary: {
+              match: "(\\B\\-|\\b)0b[01]([_01]*[01])?\\b",
+              name: "constant.numeric.integer.binary.cadence",
+            },
+            decimal: {
+              match: "(\\B\\-|\\b)[0-9]([_0-9]*[0-9])?\\b",
+              name: "constant.numeric.integer.decimal.cadence",
+            },
+            hexadecimal: {
+              match: "(\\B\\-|\\b)0x[0-9A-Fa-f]([_0-9A-Fa-f]*[0-9A-Fa-f])?\\b",
+              name: "constant.numeric.integer.hexadecimal.cadence",
+            },
+            octal: {
+              match: "(\\B\\-|\\b)0o[0-7]([_0-7]*[0-7])?\\b",
+              name: "constant.numeric.integer.octal.cadence",
+            },
+          },
+        },
+        string: {
+          patterns: [
+            {
+              begin: '"',
+              beginCaptures: {
+                0: { name: "punctuation.definition.string.begin.cadence" },
+              },
+              end: '"',
+              endCaptures: {
+                0: { name: "punctuation.definition.string.end.cadence" },
+              },
+              name: "string.quoted.double.single-line.cadence",
+              patterns: [
+                {
+                  match: "\\r|\\n",
+                  name: "invalid.illegal.returns-not-allowed.cadence",
+                },
+                { include: "#string-guts" },
+              ],
+            },
+          ],
+          repository: {
+            "string-guts": {
+              patterns: [
+                {
+                  match: "\\\\[0\\\\tnr\"']",
+                  name: "constant.character.escape.cadence",
+                },
+                {
+                  match: "\\\\u\\{[0-9a-fA-F]{1,8}\\}",
+                  name: "constant.character.escape.unicode.cadence",
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    operators: {
+      patterns: [
+        { match: "\\-", name: "keyword.operator.arithmetic.unary.cadence" },
+        { match: "!", name: "keyword.operator.logical.not.cadence" },
+        { match: "=", name: "keyword.operator.assignment.cadence" },
+        { match: "<-", name: "keyword.operator.move.cadence" },
+        { match: "<-!", name: "keyword.operator.force-move.cadence" },
+        { match: "\\+|\\-|\\*|/", name: "keyword.operator.arithmetic.cadence" },
+        { match: "%", name: "keyword.operator.arithmetic.remainder.cadence" },
+        {
+          match: "==|!=|>|<|>=|<=",
+          name: "keyword.operator.comparison.cadence",
+        },
+        { match: "\\?\\?", name: "keyword.operator.coalescing.cadence" },
+        { match: "&&|\\|\\|", name: "keyword.operator.logical.cadence" },
+        { match: "[?!]", name: "keyword.operator.type.optional.cadence" },
+      ],
+    },
+    "parameter-clause": {
+      begin: "(\\()",
+      beginCaptures: {
+        1: { name: "punctuation.definition.parameters.begin.cadence" },
+      },
+      end: "(\\))",
+      endCaptures: {
+        1: { name: "punctuation.definition.parameters.end.cadence" },
+      },
+      name: "meta.parameter-clause.cadence",
+      patterns: [{ include: "#parameter-list" }],
+    },
+    "parameter-list": {
+      patterns: [
+        {
+          captures: {
+            1: { name: "entity.name.function.cadence" },
+            2: { name: "variable.parameter.function.cadence" },
+          },
+          match: "([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)\\s+([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)(?=\\s*:)",
+        },
+        {
+          captures: {
+            1: { name: "variable.parameter.function.cadence" },
+            2: { name: "entity.name.function.cadence" },
+          },
+          match: "(([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*))(?=\\s*:)",
+        },
+        {
+          begin: ":\\s*(?!\\s)",
+          end: "(?=[,)])",
+          patterns: [
+            { include: "#type" },
+            {
+              match: ":",
+              name: "invalid.illegal.extra-colon-in-parameter-list.cadence",
+            },
+          ],
+        },
+      ],
+    },
+    type: {
+      patterns: [
+        { include: "#comments" },
+        {
+          match: "([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)",
+          name: "storage.type.cadence",
+        },
+      ],
+    },
+    "var-let-declaration": {
+      begin: "\\b(var|let)\\b\\s+([\\p{L}_][\\p{L}_\\p{N}\\p{M}]*)",
+      beginCaptures: {
+        1: { name: "storage.type.$1.cadence" },
+        2: { name: "entity.name.type.$1.cadence" },
+      },
+      end: "=|<-|<-!|$",
+      patterns: [{ include: "#type" }],
+    },
+  },
+  scopeName: "source.cadence",
+};
+
+export default grammar;

--- a/src/components/flowscan/CodeBlock/configureCadence.ts
+++ b/src/components/flowscan/CodeBlock/configureCadence.ts
@@ -1,0 +1,177 @@
+export default function configureCadence(monaco: any) {
+  monaco.languages.register({
+    id: "cadence",
+    extensions: [".cdc"],
+    aliases: ["CDC", "cdc"],
+  });
+
+  const languageDef = {
+    keywords: [
+      "if",
+      "else",
+      "return",
+      "continue",
+      "break",
+      "while",
+      "pre",
+      "post",
+      "prepare",
+      "execute",
+      "import",
+      "from",
+      "create",
+      "destroy",
+      "priv",
+      "pub",
+      "get",
+      "set",
+      "log",
+      "emit",
+      "event",
+      "init",
+      "struct",
+      "interface",
+      "fun",
+      "let",
+      "var",
+      "resource",
+      "access",
+      "all",
+      "contract",
+      "self",
+      "transaction",
+    ],
+
+    typeKeywords: [
+      "AnyStruct",
+      "AnyResource",
+      "Void",
+      "Never",
+      "String",
+      "Character",
+      "Bool",
+      "Self",
+      "Int8",
+      "Int16",
+      "Int32",
+      "Int64",
+      "Int128",
+      "Int256",
+      "UInt8",
+      "UInt16",
+      "UInt32",
+      "UInt64",
+      "UInt128",
+      "UInt256",
+      "Word8",
+      "Word16",
+      "Word32",
+      "Word64",
+      "Word128",
+      "Word256",
+      "Fix64",
+      "UFix64",
+    ],
+
+    operators: [
+      "<-",
+      "<=",
+      ">=",
+      "==",
+      "!=",
+      "+",
+      "-",
+      "*",
+      "/",
+      "%",
+      "&",
+      "!",
+      "&&",
+      "||",
+      "?",
+      "??",
+      ":",
+      "=",
+      "@",
+    ],
+
+    // we include these common regular expressions
+    symbols: /[=><!~?:&|+\-*\\^%]+/,
+    escapes: /\\(?:[abfnrtv\\"]|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+    digits: /\d+(_+\d+)*/,
+    octaldigits: /[0-7]+(_+[0-7]+)*/,
+    binarydigits: /[0-1]+(_+[0-1]+)*/,
+    hexdigits: /[[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
+
+    tokenizer: {
+      root: [[/[{}]/, "delimiter.bracket"], { include: "common" }],
+
+      common: [
+        // identifiers and keywords
+        [
+          /[a-z_$][\w$]*/,
+          {
+            cases: {
+              "@typeKeywords": "keyword",
+              "@keywords": "keyword",
+              "@default": "identifier",
+            },
+          },
+        ],
+        [/[A-Z][\w]*/, "type.identifier"], // to show class names nicely
+
+        // whitespace
+        { include: "@whitespace" },
+
+        // delimiters and operators
+        [/[()[\]]/, "@brackets"],
+        [/[<>](?!@symbols)/, "@brackets"],
+        [
+          /@symbols/,
+          {
+            cases: {
+              "@operators": "delimiter",
+              "@default": "",
+            },
+          },
+        ],
+
+        // numbers
+        [/(@digits)[eE]([-+]?(@digits))?/, "number.float"],
+        [/(@digits)\.(@digits)([eE][-+]?(@digits))?/, "number.float"],
+        [/0[xX](@hexdigits)/, "number.hex"],
+        [/0[oO]?(@octaldigits)/, "number.octal"],
+        [/0[bB](@binarydigits)/, "number.binary"],
+        [/(@digits)/, "number"],
+
+        // delimiter: after number because of .\d floats
+        [/[;,.]/, "delimiter"],
+
+        // strings
+        [/"([^"\\]|\\.)*$/, "string.invalid"], // non-teminated string
+        [/"/, "string", "@string_double"],
+      ],
+
+      whitespace: [
+        [/[ \t\r\n]+/, ""],
+        [/\/\*/, "comment", "@comment"],
+        [/\/\/.*$/, "comment"],
+      ],
+
+      comment: [
+        [/[^/*]+/, "comment"],
+        [/\*\//, "comment", "@pop"],
+        [/[/*]/, "comment"],
+      ],
+
+      string_double: [
+        [/[^\\"]+/, "string"],
+        [/@escapes/, "string.escape"],
+        [/\\./, "string.escape.invalid"],
+        [/"/, "string", "@pop"],
+      ],
+    },
+  };
+
+  monaco.languages.setMonarchTokensProvider("cadence", languageDef);
+}

--- a/src/components/flowscan/CodeBlock/index.tsx
+++ b/src/components/flowscan/CodeBlock/index.tsx
@@ -1,0 +1,218 @@
+/* --------------------------------------------------------------------------------------------- */
+"use client";
+/* --------------------------------------------------------------------------------------------- */
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
+import MonacoEditor, { DiffEditor, Monaco, MonacoDiffEditor } from "@monaco-editor/react";
+import configureCadence from "./configureCadence";
+import type { Highlight } from "./types.ts";
+
+/* --------------------------------------------------------------------------------------------- */
+
+interface Props {
+  code: string;
+  diff?: string;
+  showDiff?: boolean;
+  highlights?: Array<Highlight>;
+  setEditorPropLift?: Dispatch<SetStateAction<any>>;
+}
+
+interface Vars {
+  editor: any; // we can fix this by importing monaco-editor package and getting "editor" namespace from it later
+  monaco: Monaco | null;
+}
+
+function addHighlight(monaco: Monaco) {
+  return function (highlight: Highlight) {
+    const { row, errorMessage } = highlight;
+
+    return {
+      range: new monaco.Range(row, 1, row, 1),
+      options: {
+        isWholeLine: true,
+        className: "cadence-error",
+        inlineClassName: "cadence-error",
+        after: {
+          content: "Error: " + errorMessage,
+          margin: "10px",
+          color: "red",
+        },
+      },
+    };
+  };
+}
+
+const makeTheme = (monaco: any, themeName: string) => {
+  const baseName = themeName.split("-")[1];
+  const base = baseName === "dark" ? "vs-dark" : "vs";
+
+  const editorTheme = `custom-${base}`;
+  monaco.editor.defineTheme(editorTheme, {
+    base,
+    inherit: true,
+    rules: [],
+    colors: {
+      "editor.background": "#2e353f",
+    },
+  });
+  monaco.editor.setTheme(editorTheme);
+};
+
+export default function CodeBlock(props: Props) {
+  const { code, highlights, setEditorPropLift } = props;
+  const { showDiff, diff } = props;
+
+  const themeName = "fd-dark";
+
+  const [vars, setVars] = useState<Vars>({
+    editor: null,
+    monaco: null,
+  });
+  const options = {
+    readOnly: true,
+    minimap: {
+      enabled: false,
+    },
+    scrollbar: {
+      handleMouseWheel: true,
+      alwaysConsumeMouseWheel: false,
+    },
+    wordWrap: "on",
+    automaticLayout: true,
+    scrollBeyondLastLine: false,
+    scrollBeyondLastColumn: false,
+    wrappingStrategy: "advanced",
+  };
+
+  const decorations = useRef<any>(null);
+  const editorContainer = useRef<HTMLDivElement>(null);
+  const debouncedTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (vars) {
+      const { editor, monaco } = vars;
+      if (editor && monaco) {
+        if (decorations.current) {
+          decorations.current.clear();
+        }
+        if (setEditorPropLift) {
+          setEditorPropLift(editor);
+        }
+        const mapHighlight = addHighlight(monaco);
+        decorations.current = editor.createDecorationsCollection(
+          (highlights || []).map(mapHighlight),
+        );
+      }
+    }
+  }, [highlights, vars]);
+  useEffect(() => {
+    if (vars.monaco) {
+      makeTheme(vars.monaco, themeName);
+    }
+  }, [themeName]);
+
+  function registerResizeListener(editor: any) {
+    const resizeObserver = new ResizeObserver(() => {
+      if (debouncedTimerRef.current) {
+        clearTimeout(debouncedTimerRef.current);
+      }
+      debouncedTimerRef.current = setTimeout(() => {
+        editor.layout();
+        debouncedTimerRef.current = null;
+      }, 150);
+    });
+    resizeObserver.observe(editorContainer.current!);
+  }
+
+  const onMount = (editor: any, monaco: any) => {
+    configureCadence(monaco);
+    makeTheme(monaco, themeName);
+    setVars({ editor, monaco });
+
+    /*    themeContext.addReaction("monaco-theme", (theme: ThemeInterface) => {
+      makeTheme(monaco, theme);
+    });*/
+
+    // editor.updateOptions({wordWrap: "on"})
+    const editorElement = editor && editor.getDomNode && editor?.getDomNode();
+
+    if (!editorElement) {
+      return;
+    }
+
+    const lineHeight = editor.getOption(monaco.editor.EditorOption.lineHeight);
+    const lineCount = editor.getModel()?.getLineCount() + 2 || 1;
+    const height = lineHeight * lineCount;
+    editorElement.style.height = `${height}px`;
+    editor.layout();
+    registerResizeListener(editor);
+  };
+
+  const onDiffMount = (editor: MonacoDiffEditor, monaco: any) => {
+    configureCadence(monaco);
+    makeTheme(monaco, themeName);
+    setVars({ editor, monaco });
+
+    /*    themeContext.addReaction("monaco-theme", (theme: ThemeInterface) => {
+      makeTheme(monaco, theme);
+    });*/
+
+    // editor.updateOptions({wordWrap: "on"})
+    const diffEditor = editor.getOriginalEditor();
+    const editorElement = editor && editor.getContainerDomNode && editor?.getContainerDomNode();
+
+    if (!editorElement) {
+      return;
+    }
+
+    const lineHeight = diffEditor.getOption(monaco.editor.EditorOption.lineHeight);
+
+    const originalLineCount = editor.getOriginalEditor().getModel()?.getLineCount() || 0;
+    const diffLineCount = editor.getModifiedEditor().getModel()?.getLineCount() || 0;
+
+    const lineCount = Math.max(originalLineCount, diffLineCount);
+
+    const height = lineHeight * lineCount;
+    editorElement.style.height = `${height}px`;
+    editor.layout();
+    registerResizeListener(editor);
+  };
+
+  const editorWithDiff = showDiff && diff;
+
+  return (
+    <div
+      ref={editorContainer}
+      className="flex h-full w-full flex-col items-start gap-4 overflow-hidden bg-blue-dark [&:last-child]:mb-0 [&_section]:min-h-[40vh]">
+      {!editorWithDiff && (
+        <MonacoEditor
+          language={"cadence"}
+          value={code}
+          height={"100%"}
+          options={{
+            ...(options as any),
+            fontSize: 14,
+            renderLineHighlight: "none",
+            automaticLayout: false,
+            // scrollbar: {
+            //   verticalScrollbarSize: 5,
+            // },
+          }}
+          onMount={onMount}
+          beforeMount={(monaco: any) => makeTheme(monaco, themeName)}
+        />
+      )}
+
+      {editorWithDiff && (
+        <DiffEditor
+          height={"100%"}
+          language={"cadence"}
+          original={diff}
+          modified={code}
+          onMount={onDiffMount}
+          options={{ ...(options as any), renderSideBySide: false, fontSize: 14 }}
+          beforeMount={(monaco: any) => makeTheme(monaco, themeName)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/flowscan/CodeBlock/types.ts
+++ b/src/components/flowscan/CodeBlock/types.ts
@@ -1,0 +1,4 @@
+export interface Highlight {
+  row: number;
+  errorMessage: string;
+}

--- a/src/components/flowscan/CodeBlock/types.tsx
+++ b/src/components/flowscan/CodeBlock/types.tsx
@@ -1,0 +1,20 @@
+export type BuiltinTheme = "vs" | "vs-dark" | "hc-black" | "hc-light";
+
+export interface IStandaloneThemeData {
+  base: BuiltinTheme;
+  inherit: boolean;
+  rules: ITokenThemeRule[];
+  encodedTokensColors?: string[];
+  colors: IColors;
+}
+
+export type IColors = {
+  [colorId: string]: string;
+};
+
+export interface ITokenThemeRule {
+  token: string;
+  foreground?: string;
+  background?: string;
+  fontStyle?: string;
+}

--- a/src/components/flowscan/ExtraTag/index.tsx
+++ b/src/components/flowscan/ExtraTag/index.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { SquareArrowUpRight } from "lucide-react";
+
+export enum ExtraTagType {
+  "success",
+  "failure",
+  "warning",
+  "net_flow",
+  "net_evm",
+  "net_empty",
+  "net_mixed",
+  "evm_contract",
+  "evm_token",
+  "flow_tag",
+  "system",
+  "system_fee",
+  "system_signers",
+}
+
+function getTagColor(type: ExtraTagType) {
+  const colors: Record<ExtraTagType, string> = {
+    [ExtraTagType.success]: "text-green-200",
+    [ExtraTagType.failure]: "text-red-600",
+    [ExtraTagType.warning]: "text-red-300",
+
+    [ExtraTagType.net_flow]: "text-green-100",
+    [ExtraTagType.net_evm]: "text-blue-400",
+    [ExtraTagType.net_mixed]: "text-purple-600",
+    [ExtraTagType.net_empty]: "text-neutral-100",
+
+    [ExtraTagType.evm_contract]: "text-blue-300",
+    [ExtraTagType.evm_token]: "text-red-400",
+
+    [ExtraTagType.flow_tag]: "text-green-800",
+
+    [ExtraTagType.system]: "text-neutral-25",
+    [ExtraTagType.system_fee]: "text-neutral-100",
+    [ExtraTagType.system_signers]: "text-blue-500",
+  };
+
+  return colors[type];
+}
+
+export type TagSize = "tiny" | "small" | "medium";
+
+interface CommonTagProps {
+  label: string | React.ReactNode;
+  title?: string;
+  category?: string | React.ReactNode;
+  size?: TagSize;
+  className?: string;
+  labelClassName?: string;
+  isLink?: boolean;
+  hideLink?: boolean;
+  style?: React.CSSProperties;
+}
+
+type ExtraTagProps =
+  | (CommonTagProps & {
+      type: ExtraTagType;
+    })
+  | (CommonTagProps & { type?: never; customType: string });
+
+const textSize = {
+  tiny: "text-tiny",
+  small: "text-tiny",
+  medium: "text-fineprint",
+};
+
+export function ExtraTag(props: ExtraTagProps) {
+  const { category } = props;
+  const { title, label } = props;
+  const { size = "small" } = props;
+  const { className, labelClassName } = props;
+  const { isLink, hideLink, style } = props;
+
+  let content = (
+    <b className={"flex flex-row items-center gap-1"}>
+      <span>{label}</span>
+      {!hideLink && (
+        <SquareArrowUpRight
+          className={
+            "relative bottom-[0.5px] hidden h-4 w-4 flex-shrink-0 opacity-50 [:where(a)_&]:block"
+          }
+        />
+      )}
+    </b>
+  );
+
+  if (!!category) {
+    content = (
+      <div
+        style={style}
+        className={"flex flex-row items-center justify-start gap-1"}
+      >
+        <span
+          className={cn(
+            "inline-grid max-w-[8rem] place-items-center truncate opacity-75",
+            "[&>svg]:h-4 [&>svg]:w-4"
+          )}
+        >
+          {category}
+        </span>
+        <span className={"opacity-75"}>|</span>
+        <div
+          className={cn(
+            "flex items-center justify-start gap-1 px-0.5 font-bold",
+            labelClassName
+          )}
+        >
+          <span className={"max-w-[8rem] truncate"}>{label}</span>
+          {!hideLink && (
+            <SquareArrowUpRight
+              className={
+                "relative bottom-[0.5px] hidden h-4 w-4 flex-shrink-0 opacity-50 [:where(a)_&]:block"
+              }
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+  const colorClass =
+    typeof props.type == "undefined"
+      ? props.customType
+      : getTagColor(props.type);
+  const sizeClass = textSize[size as keyof typeof textSize];
+
+  return (
+    <span
+      className={cn(
+        "flex flex-shrink-0 items-center justify-center",
+        "border-[1px] border-solid border-current",
+        "p-1",
+        colorClass,
+        sizeClass,
+        className
+      )}
+      title={title || (typeof label === "string" ? label : "")}
+    >
+      {content}
+    </span>
+  );
+}


### PR DESCRIPTION
feat: add contracts page and content for account details

- Implemented AccountContractsContent component to display contracts associated with an account.
- Created AccountContracts page to wrap AccountContractsContent in a Suspense fallback.
- Updated AccountNavigation to include a link to the new contracts page.
- Added Cadence syntax highlighting support with a new TextMate grammar.
- Configured Monaco editor for Cadence language with custom themes and highlighting.
- Developed CodeBlock component to render Cadence code with optional diff view.
- Introduced ExtraTag component for displaying contextual tags with various styles.